### PR TITLE
fix: opphub storage class goes under cloudprovider not clustergroup

### DIFF
--- a/values-opphub.yaml
+++ b/values-opphub.yaml
@@ -1,6 +1,8 @@
 clusterGroup:
   name: hub
   isHubCluster: true
+
+cloudProvider:
   storageClass: gp2
 
 # Namespaces that are expected to be created.


### PR DESCRIPTION
Following a slack channel thread, `values-opphub.yaml` is not inline with the common schema, which makes linting fail:

```shell
$ ./pattern.sh make validate-schema

make -f common/Makefile validate-schema
...
Error: values don't meet the specifications of the schema(s) in the following chart(s):
clustergroup:
- clusterGroup: Additional property storageClass is not allowed

make[1]: *** [common/Makefile:110: validate-schema] Error 1
...
make: *** [Makefile:12: validate-schema] Error 2
```

Schema update PR: https://github.com/validatedpatterns/common/pull/401

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
