### PR TITLE
Fix version of ManagedClusterSetBinding

### DIFF
--- a/charts/hub/opp/templates/clusterset-binding.yaml
+++ b/charts/hub/opp/templates/clusterset-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: default

--- a/tests/hub-opp-industrial-edge-factory.expected.yaml
+++ b/tests/hub-opp-industrial-edge-factory.expected.yaml
@@ -9,7 +9,7 @@
 #  - odf-console
 ---
 # Source: opp/templates/clusterset-binding.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: default

--- a/tests/hub-opp-industrial-edge-hub.expected.yaml
+++ b/tests/hub-opp-industrial-edge-hub.expected.yaml
@@ -9,7 +9,7 @@
 #  - odf-console
 ---
 # Source: opp/templates/clusterset-binding.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: default

--- a/tests/hub-opp-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-opp-medical-diagnosis-hub.expected.yaml
@@ -9,7 +9,7 @@
 #  - odf-console
 ---
 # Source: opp/templates/clusterset-binding.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: default

--- a/tests/hub-opp-naked.expected.yaml
+++ b/tests/hub-opp-naked.expected.yaml
@@ -9,7 +9,7 @@
 #  - odf-console
 ---
 # Source: opp/templates/clusterset-binding.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: default

--- a/tests/hub-opp-normal.expected.yaml
+++ b/tests/hub-opp-normal.expected.yaml
@@ -9,7 +9,7 @@
 #  - odf-console
 ---
 # Source: opp/templates/clusterset-binding.yaml
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: default


### PR DESCRIPTION
It's v1beta2 now: https://open-cluster-management.io/concepts/managedclusterset/

"The ManagedClusterSet and ManagedClusterSetBinding API v1beta1 version
will no longer be served in OCM v0.12.0"

Thanks to Alejandro and Tomer for bringing this up
