### PR TITLE
Drop 4.10 overrides

### DIFF
--- a/overrides/values-AWS-4.10.yaml
+++ b/overrides/values-AWS-4.10.yaml
@@ -1,3 +1,0 @@
-cloudProvider:
-  storageClass: gp2
-  provisioner: kubernetes.io/aws-ebs

--- a/overrides/values-Azure-4.10.yaml
+++ b/overrides/values-Azure-4.10.yaml
@@ -1,4 +1,0 @@
-
-cloudProvider:
-  strageClass: managed-premium
-  provisioner: kubernetes.io/azure-disk

--- a/overrides/values-GCP-4.10.yaml
+++ b/overrides/values-GCP-4.10.yaml
@@ -1,3 +1,0 @@
-cloudProvider:
-  storageClass: standard
-  provisioner: kubernetes.io/gce-pd


### PR DESCRIPTION
OCP 4.10 went out of support more than a year ago, we can drop these
overrides now.
